### PR TITLE
Added handling for SSL Termination

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,3 +136,5 @@ Upgrades unsecured requests invoking action `Authenticate`.
   The middleware will automatically add a [HSTS header](https://tools.ietf.org/html/rfc6797) unless
   `options.HstsHeader` is `null`.
 * **Policies** - The collection of policies for upgrading unsecured requests.
+
+* **Allow SSL Termination** - This option allows for the case where something like a proxy or load balancer (say HAProxy or AWS Elastic Load Balancer) is performing SSL Termination. In this case the X-Forwarded-Proto should be set to `https`, but the protocol locally will be `http`. Setting `option.AllowSslTermination = true` will handle these cases.

--- a/src/AspNetCore.SslRedirect/SslRedirectOptions.cs
+++ b/src/AspNetCore.SslRedirect/SslRedirectOptions.cs
@@ -44,6 +44,14 @@ namespace MS.AspNetCore.Ssl {
             get;
         } = new List<ISslPolicy>();
 
+        /// <summary>
+        /// Gets or sets the SslTermination Flag
+        /// </summary>
+        public bool AllowSslTermination
+        {
+            get;
+            set;
+        } = false;
     }
 
 }


### PR DESCRIPTION
- Adds AllowSslTermination option
- Checks X-Forwarded-Proto header
- Ensures that X-Forwarded-Port is used instead of the default port